### PR TITLE
Adding artist name to sql model to enable multi-artist analysis

### DIFF
--- a/concert_analytics_dbt/models/mart/mart_all_albums.sql
+++ b/concert_analytics_dbt/models/mart/mart_all_albums.sql
@@ -1,5 +1,6 @@
 select 
-	al.album_id as album_id
+	al.artist_name_hint as artist_name_hint
+	,al.album_id as album_id
 	,al.album_url as album_url
 	,al.album_uri as album_uri
 	,al.album_type as album_type

--- a/concert_analytics_dbt/models/mart/mart_all_tracks.sql
+++ b/concert_analytics_dbt/models/mart/mart_all_tracks.sql
@@ -1,5 +1,6 @@
 select 
-	album_id
+	artist_name_hint
+	,album_id
 	,album_url
 	,album_uri
 	,album_type

--- a/concert_analytics_dbt/models/mart/mart_all_tracks_versions.sql
+++ b/concert_analytics_dbt/models/mart/mart_all_tracks_versions.sql
@@ -1,6 +1,7 @@
 with album_track_joined as (
 	select 
-		al.album_id as album_id
+		al.artist_name_hint as artist_name_hint
+		,al.album_id as album_id
 		,al.album_url as album_url
 		,al.album_uri as album_uri
 		,al.album_type as album_type
@@ -29,7 +30,8 @@ with album_track_joined as (
 )
 , album_track_ranked as (
 	select 
- 		album_id
+ 		artist_name_hint
+ 		,album_id
 		,album_url
 		,album_uri
 		,album_type
@@ -49,7 +51,8 @@ with album_track_joined as (
 		,track_irsc
  		,ROW_NUMBER() OVER (
 			PARTITION BY 
-				LOWER(track_name)
+				artist_name_hint
+				,LOWER(track_name)
 			ORDER BY
 		    	CASE 
 			    	WHEN album_type = 'album' THEN 0 
@@ -61,7 +64,8 @@ with album_track_joined as (
 	 	album_track_joined
 )
 select 
-	album_id
+	artist_name_hint
+	,album_id
 	,album_url
 	,album_uri
 	,album_type

--- a/concert_analytics_dbt/models/mart/mart_event_summary.sql
+++ b/concert_analytics_dbt/models/mart/mart_event_summary.sql
@@ -1,6 +1,7 @@
 with event_summary as (
 	select 
-		event_id
+		artist_name_hint
+		,event_id
 		,event_date
 		,event_info
 		,event_url
@@ -23,12 +24,12 @@ with event_summary as (
 			when encore_flag = false then event_set_song_id 
 			end 
 			) as event_total_non_encore_songs
-		,lag(event_date) over (order by event_date asc) as event_last_date	
-		,lag(event_tour_id) over (order by event_date asc) as event_last_tour_id
+		,lag(event_date) over (partition by artist_name_hint order by event_date asc) as event_last_date	
+		,lag(event_tour_id) over (partition by artist_name_hint order by event_date asc) as event_last_tour_id
 	from 
 		{{ ref('stg_setlist_history') }}
 	group by 
-		1,2,3,4,5,6,7,8,9,10,11,12,13
+		1,2,3,4,5,6,7,8,9,10,11,12,13,14
 ), new_tour_flag as (
 	select 
 		*
@@ -47,7 +48,8 @@ with event_summary as (
 		new_tour_flag
 )
 select 
-	event_id
+	artist_name_hint
+	,event_id
 	,event_date
 	,event_info
 	,event_url
@@ -66,6 +68,6 @@ select
 	,event_total_non_encore_songs
 	,event_last_date
 	,event_last_tour_id
-	,md5('mewithoutyou'||tour_psuedo_counter) as event_tour_pseudo_id
+	,md5(artist_name_hint||tour_psuedo_counter) as event_tour_pseudo_id
 from 
 	tour_psuedo_counter

--- a/concert_analytics_dbt/models/mart/mart_setlist_history.sql
+++ b/concert_analytics_dbt/models/mart/mart_setlist_history.sql
@@ -1,7 +1,8 @@
 -- models/mart/mart_setlist_history.sql
 
 select 
-	event_set_song_id
+	artist_name_hint
+	,event_set_song_id
 	,event_id
 	,event_date
 	,event_info
@@ -31,8 +32,8 @@ select
 	,song_with_flag
 	,song_with_artist_mbid
 	,song_with_artist_name  
-	,lag(event_set_song_id) over (partition by song_name order by event_date desc) as song_last_event_set_song_id	
-	,lag(event_id) over (partition by song_name order by event_date desc) as song_last_event_id
-	,lag(event_date) over (partition by song_name order by event_date desc) as song_last_event_date
+	,lag(event_set_song_id) over (partition by artist_name_hint,song_name order by event_date desc) as song_last_event_set_song_id	
+	,lag(event_id) over (partition by artist_name_hint,song_name order by event_date desc) as song_last_event_id
+	,lag(event_date) over (partition by artist_name_hint,song_name order by event_date desc) as song_last_event_date
 from 
 	{{ ref('stg_setlist_history') }}

--- a/concert_analytics_dbt/models/mart/mart_track_setlist_similarity_scores.sql
+++ b/concert_analytics_dbt/models/mart/mart_track_setlist_similarity_scores.sql
@@ -4,7 +4,8 @@
 ) }}
 
 select 
-	sh.song_name as song_name
+	sh.artist_name_hint as artist_name_hint
+	, sh.song_name as song_name
 	, atr.track_name as track_name
 	, sh.event_set_song_id as event_set_song_id
 	, atr.track_id as track_id
@@ -19,4 +20,5 @@ from
 	{{ ref('mart_setlist_history') }} as sh
 	join {{ ref('mart_all_tracks') }} as atr
 		on analytics_mart.similarity(sh.song_name::text, atr.track_name::text) > 0.2
+		and sh.artist_name_hint = atr.artist_name_hint
 where true

--- a/concert_analytics_dbt/models/staging/schema.yml
+++ b/concert_analytics_dbt/models/staging/schema.yml
@@ -32,6 +32,10 @@ sources:
       - name: artist_tracks_metadata
         description: "Metadata on tracks from spotify loaded by python"
 
+      - name: artist_name_hint
+        data_type: character varying
+        description: "Name hint used to pull data, will help join different bands datasets"
+
 models:
   - name: stg_artist_tracks
     description: ""
@@ -72,6 +76,10 @@ models:
         data_type: bigint
         description: ""
 
+      - name: artist_name_hint
+        data_type: character varying
+        description: "Name hint used to pull data, will help join different bands datasets"
+
   - name: stg_artist_albums
     description: ""
     columns:
@@ -106,6 +114,10 @@ models:
       - name: album_image_url
         data_type: text
         description: ""
+
+      - name: artist_name_hint
+        data_type: character varying
+        description: "Name hint used to pull data, will help join different bands datasets"
 
   - name: stg_setlist_history
     description: "Cleaned and structured setlist data from raw.setlist_history"
@@ -217,6 +229,10 @@ models:
         data_type: text
         description: ""
 
+      - name: artist_name_hint
+        data_type: character varying
+        description: "Name hint used to pull data, will help join different bands datasets"
+
   - name: stg_artist_albums_metadata
     description: ""
     columns:
@@ -227,6 +243,10 @@ models:
       - name: album_popularity
         data_type: integer
         description: ""
+
+      - name: artist_name_hint
+        data_type: character varying
+        description: "Name hint used to pull data, will help join different bands datasets"
 
   - name: stg_artist_tracks_metadata
     description: ""
@@ -242,3 +262,7 @@ models:
       - name: track_isrc
         data_type: character varying
         description: ""
+
+      - name: artist_name_hint
+        data_type: character varying
+        description: "Name hint used to pull data, will help join different bands datasets"

--- a/concert_analytics_dbt/models/staging/stg_artist_albums.sql
+++ b/concert_analytics_dbt/models/staging/stg_artist_albums.sql
@@ -1,5 +1,6 @@
 select 
-	album_id as album_id
+	name_hint as artist_name_hint
+	,album_id as album_id
 	,album_url as album_url
 	,album_uri as album_uri
 	,album_type as album_type

--- a/concert_analytics_dbt/models/staging/stg_artist_albums_metadata.sql
+++ b/concert_analytics_dbt/models/staging/stg_artist_albums_metadata.sql
@@ -1,5 +1,6 @@
 select 
-	cast(album_id as varchar) as album_id
+	name_hint as artist_name_hint
+	,cast(album_id as varchar) as album_id
 	,cast(album_popularity as int) as album_popularity
 from 
 	{{ source('raw', 'artist_albums_metadata') }}

--- a/concert_analytics_dbt/models/staging/stg_artist_tracks.sql
+++ b/concert_analytics_dbt/models/staging/stg_artist_tracks.sql
@@ -1,5 +1,6 @@
 select 
-	track_id as track_id
+	name_hint as artist_name_hint
+	,track_id as track_id
 	,track_url as track_url
 	,track_uri as track_uri
 	,album_id as album_id

--- a/concert_analytics_dbt/models/staging/stg_artist_tracks_metadata.sql
+++ b/concert_analytics_dbt/models/staging/stg_artist_tracks_metadata.sql
@@ -1,5 +1,6 @@
 select 
-	cast(track_id as varchar) as track_id
+	name_hint as artist_name_hint
+	,cast(track_id as varchar) as track_id
 	,cast(track_popularity as int) as track_popularity
 	,cast(track_isrc as varchar) as track_isrc
 from 

--- a/concert_analytics_dbt/models/staging/stg_setlist_history.sql
+++ b/concert_analytics_dbt/models/staging/stg_setlist_history.sql
@@ -1,5 +1,6 @@
 select 
-	md5(event_id||set_index||song_index) as event_set_song_id
+	name_hint as artist_name_hint
+	,md5(event_id||set_index||song_index) as event_set_song_id
 	,event_id as event_id
 	,TO_DATE(event_date, 'DD-MM-YYYY') as event_date 
 	,event_info as event_info

--- a/concert_analytics_dbt/models/staging/stg_setlist_history.sql
+++ b/concert_analytics_dbt/models/staging/stg_setlist_history.sql
@@ -1,11 +1,11 @@
 select 
 	name_hint as artist_name_hint
-	,md5(event_id||set_index||song_index) as event_set_song_id
+	,md5(name_hint||event_id||set_index||song_index) as event_set_song_id
 	,event_id as event_id
 	,TO_DATE(event_date, 'DD-MM-YYYY') as event_date 
 	,event_info as event_info
 	,event_url as event_url
-	,md5(tour_name) as event_tour_id
+	,md5(name_hint||tour_name) as event_tour_id
 	,tour_name as event_tour
 	,md5(venue||venue_city||venue_state_code||venue_country_code) as venue_id
 	,venue as venue_name

--- a/setlistfm/utils.py
+++ b/setlistfm/utils.py
@@ -55,7 +55,7 @@ def cached_json(fetch_func, mbid, *args, name_hint=None, force=False, cache_mode
     save_json(data, filename)
     return data
 
-def setlists_to_dataframe(setlists):
+def setlists_to_dataframe(setlists, name_hint):
     """
     Convert setlist.fm data into a pandas DataFrame where each row is a song performance.
 
@@ -101,7 +101,8 @@ def setlists_to_dataframe(setlists):
                     song_withArtistMbid = song.get("with",{}).get("mbid")
 
                     rows.append({
-                        "event_date": event_date
+                        "name_hint": name_hint
+                        ,"event_date": event_date
                         , "event_id": event_id
                         , "event_info": event_info
                         , "event_url": event_url
@@ -154,4 +155,4 @@ def setlist_dataframe(mbid, sample=True, force_refresh=False, name_hint=None, sa
         cache_mode=cache_mode
     )
 
-    return setlists_to_dataframe(setlists)
+    return setlists_to_dataframe(setlists,name_hint)

--- a/spotify/utils.py
+++ b/spotify/utils.py
@@ -156,7 +156,7 @@ def get_track_metadata_for_artist(spotifyuri, *args, name_hint=None, force=False
 
 
 
-def albums_to_dataframe(albums):
+def albums_to_dataframe(albums,name_hint):
     """
     Convert spotify web API data into a pandas DataFrame where each row is a song performance.
 
@@ -181,7 +181,8 @@ def albums_to_dataframe(albums):
         album_image_url = al.get("images", [{}])[0].get("url")
 
         rows.append({
-            "album_id": album_id
+            "name_hint": name_hint
+            , "album_id": album_id
             , "album_url": album_url
             , "album_uri": album_uri
             , "album_type": album_type
@@ -217,10 +218,10 @@ def albums_dataframe(spotifyuri, force_refresh=False, name_hint=None):
         ,force=force_refresh
     )
 
-    return albums_to_dataframe(album_data)
+    return albums_to_dataframe(album_data, name_hint)
 
 
-def album_tracks_to_dataframe(album_tracks):
+def album_tracks_to_dataframe(album_tracks,name_hint):
     """
     Convert spotify web API data into a pandas DataFrame where each row is a song performance.
 
@@ -243,7 +244,8 @@ def album_tracks_to_dataframe(album_tracks):
         track_number = tr.get("track_number")
 
         rows.append({
-            "track_id": track_id
+            "name_hint": name_hint
+            , "track_id": track_id
             , "track_url": track_url
             , "track_uri": track_uri
             , "album_id": album_id
@@ -276,11 +278,11 @@ def album_tracks_dataframe(spotifyuri, force_refresh=False, name_hint=None):
         ,force=force_refresh
     )
 
-    return album_tracks_to_dataframe(album_tracks_data)
+    return album_tracks_to_dataframe(album_tracks_data,name_hint)
 
 
 
-def albums_metadata_to_dataframe(albums):
+def albums_metadata_to_dataframe(albums,name_hint):
     """
     Convert spotify web API data into a pandas DataFrame where each row is a song performance.
 
@@ -297,7 +299,8 @@ def albums_metadata_to_dataframe(albums):
         album_popularity = al.get("popularity")
 
         rows.append({
-            "album_id": album_id
+            "name_hint": name_hint
+            ,"album_id": album_id
             , "album_popularity": album_popularity
         })
 
@@ -324,10 +327,10 @@ def albums_metadata_dataframe(spotifyuri, force_refresh=False, name_hint=None):
         ,force=force_refresh
     )
 
-    return albums_metadata_to_dataframe(album_metadata)
+    return albums_metadata_to_dataframe(album_metadata,name_hint)
 
 
-def tracks_metadata_to_dataframe(tracks):
+def tracks_metadata_to_dataframe(tracks, name_hint):
     """
     Convert spotify web API data into a pandas DataFrame where each row is a song performance.
 
@@ -345,7 +348,8 @@ def tracks_metadata_to_dataframe(tracks):
         track_isrc = tr.get("external_ids",{}).get("isrc")
 
         rows.append({
-            "track_id": track_id
+            "name_hint": name_hint
+            ,"track_id": track_id
             , "track_popularity": track_popularity
             ,"track_isrc": track_isrc
         })
@@ -373,4 +377,4 @@ def tracks_metadata_dataframe(spotifyuri, force_refresh=False, name_hint=None):
         ,force=force_refresh
     )
 
-    return tracks_metadata_to_dataframe(tracks_metadata)
+    return tracks_metadata_to_dataframe(tracks_metadata,name_hint)


### PR DESCRIPTION
- changed spotify and setlist fm dataframes to include name hint 
- reworked models to include name hint in them 
- modified upsert functions to postgress to allow for multi-artist imports (will only upsert new namehint/artist)